### PR TITLE
Add client to handle communication

### DIFF
--- a/analogbridge.gemspec
+++ b/analogbridge.gemspec
@@ -21,7 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rest-client", "~> 2.0"
+
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 2.0"
 end

--- a/lib/analogbridge.rb
+++ b/lib/analogbridge.rb
@@ -1,4 +1,6 @@
 require "analogbridge/version"
+require "analogbridge/client"
+# require "analogbridge/product"
 
 module Analogbridge
 end

--- a/lib/analogbridge/client.rb
+++ b/lib/analogbridge/client.rb
@@ -1,0 +1,38 @@
+require "rest-client"
+require "analogbridge/configuration"
+require "analogbridge/response"
+
+module Analogbridge
+  class Client
+    attr_reader :http_method, :end_point, :attributes
+
+    def initialize(http_method, end_point, attributes = {})
+      @end_point = end_point
+      @http_method = http_method
+      @attributes = attributes
+    end
+
+    def execute
+      Response.new(execute_api_request).parse
+    end
+
+    private
+
+    def execute_api_request
+      RestClient::Request.execute(
+        method: http_method,
+        url: api_end_point,
+        payload: attributes,
+        headers: {},
+      )
+    end
+
+    def api_end_point
+      [Analogbridge.configuration.api_host, end_point].join("/")
+    end
+  end
+
+  def self.get_resource(end_point)
+    Client.new(:get, end_point).execute
+  end
+end

--- a/lib/analogbridge/response.rb
+++ b/lib/analogbridge/response.rb
@@ -1,0 +1,19 @@
+require "json"
+
+module Analogbridge
+  class Response
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+    end
+
+    def parse
+      JSON.parse(response, object_class: ResponseObject)
+    rescue JSON::ParserError => error
+      ResponseObject.new(error: error, content: "")
+    end
+  end
+
+  class ResponseObject < OpenStruct; end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Analogbridge::Client do
+  describe ".get_resource" do
+    it "loads the resource via :get" do
+      stub_get_resource_request("ping")
+      resource = Analogbridge.get_resource("ping")
+
+      expect(resource.data).to eq("Pong!")
+    end
+  end
+
+  def stub_get_resource_request(end_point)
+    stub_request(
+      :get, [Analogbridge.configuration.api_host, end_point].join("/")
+    ).and_return(status: 200, body: JSON.generate(data: "Pong!"))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
+require "webmock/rspec"
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "analogbridge"


### PR DESCRIPTION
This commit streamline the communication between the API server and the client library, it will also prepare all the data as it will require and then parse the response as `OpenStuct` object.