### PR TITLE
Add interface to retrieve `products`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ $ gem install analogbridge
 
 ## Usage
 
-TODO: Write usage instructions here
+### Listing Product
+
+To retrieve the `products` simply use the following interface
+
+```ruby
+Analog::Product.all
+```
 
 ## Development
 

--- a/lib/analogbridge.rb
+++ b/lib/analogbridge.rb
@@ -1,6 +1,6 @@
 require "analogbridge/version"
 require "analogbridge/client"
-# require "analogbridge/product"
+require "analogbridge/product"
 
 module Analogbridge
 end

--- a/lib/analogbridge/product.rb
+++ b/lib/analogbridge/product.rb
@@ -1,0 +1,11 @@
+module Analogbridge
+  class Product
+    def all
+      Analogbridge.get_resource("products")
+    end
+
+    def self.all
+      new.all
+    end
+  end
+end

--- a/spec/fixtures/products.json
+++ b/spec/fixtures/products.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "35mm Slides",
+    "price": 0.69,
+    "url": "https://analogbridge.s3.amazonaws.com/images/format_35mmslides.jpg",
+    "product_id": 13,
+    "unit_name": "slide",
+    "category_name": "image"
+  },
+  {
+    "name": "Super 8mm Film",
+    "price": 14.5,
+    "url": "https://analogbridge.s3.amazonaws.com/images/format_super8.jpg",
+    "product_id": 16,
+    "unit_name": "50ft reel",
+    "category_name": "film"
+  }
+]

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Analogbridge::Product do
+  describe ".all" do
+    it "lists all existing product" do
+      stub_analogbridge_product_listing
+      products = Analogbridge::Product.all
+
+      expect(products.count).to eq(2)
+      expect(products.first.name).to eq("35mm Slides")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,11 @@
 require "webmock/rspec"
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "analogbridge"
+
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
+
+RSpec.configure do |config|
+  config.before :suite do
+    config.include FakeAnalogbridgeApi
+  end
+end

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -1,0 +1,43 @@
+module FakeAnalogbridgeApi
+  def stub_analogbridge_product_listing
+    stub_api_response(
+      :get,
+      "products",
+      filename: "products",
+      status: 200,
+    )
+  end
+
+  private
+
+  def stub_api_response(method, end_point, filename:, status:, data: nil)
+    stub_request(method, api_end_point(end_point)).
+      with(api_request_headers(data: data)).
+      to_return(response_with(filename: filename, status: status))
+  end
+
+  def api_end_point(end_point)
+    [Analogbridge.configuration.api_host, end_point].join("/")
+  end
+
+  def api_request_headers(data:)
+    Hash.new.tap do |request_headers|
+      request_headers[:body] = data
+    end
+  end
+
+  def api_authorization_headers
+    {}
+  end
+
+  def response_with(filename:, status:)
+    { body: fixture_file(filename), status: status }
+  end
+
+  def fixture_file(filename)
+    file_name = [filename, "json"].join(".")
+    file_path = ["../../", "fixtures", file_name].join("/")
+
+    File.read(File.expand_path(file_path, __FILE__))
+  end
+end


### PR DESCRIPTION
This commit adds the interface to retrieve the products using the `Analogbridge` API. To retrieve the product we can simply use the following interface.

```ruby
Analogbridge::Product.all
```