### PR TITLE
Add `AnalogBridge` as base namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ gem install analogbridge
 To retrieve the `products` simply use the following interface
 
 ```ruby
-Analog::Product.all
+AnalogBridge::Product.all
 ```
 
 ## Development

--- a/analogbridge.gemspec
+++ b/analogbridge.gemspec
@@ -5,7 +5,7 @@ require "analogbridge/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "analogbridge"
-  spec.version       = Analogbridge::VERSION
+  spec.version       = AnalogBridge::VERSION
   spec.authors       = ["Analog Bridge"]
   spec.email         = ["support@analogbridge.io"]
 

--- a/lib/analogbridge.rb
+++ b/lib/analogbridge.rb
@@ -2,5 +2,5 @@ require "analogbridge/version"
 require "analogbridge/client"
 require "analogbridge/product"
 
-module Analogbridge
+module AnalogBridge
 end

--- a/lib/analogbridge/client.rb
+++ b/lib/analogbridge/client.rb
@@ -2,7 +2,7 @@ require "rest-client"
 require "analogbridge/configuration"
 require "analogbridge/response"
 
-module Analogbridge
+module AnalogBridge
   class Client
     attr_reader :http_method, :end_point, :attributes
 
@@ -28,7 +28,7 @@ module Analogbridge
     end
 
     def api_end_point
-      [Analogbridge.configuration.api_host, end_point].join("/")
+      [AnalogBridge.configuration.api_host, end_point].join("/")
     end
   end
 

--- a/lib/analogbridge/configuration.rb
+++ b/lib/analogbridge/configuration.rb
@@ -1,4 +1,4 @@
-module Analogbridge
+module AnalogBridge
   class Configuration
     attr_reader :api_base, :api_version
 

--- a/lib/analogbridge/product.rb
+++ b/lib/analogbridge/product.rb
@@ -1,7 +1,7 @@
-module Analogbridge
+module AnalogBridge
   class Product
     def all
-      Analogbridge.get_resource("products")
+      AnalogBridge.get_resource("products")
     end
 
     def self.all

--- a/lib/analogbridge/response.rb
+++ b/lib/analogbridge/response.rb
@@ -1,6 +1,6 @@
 require "json"
 
-module Analogbridge
+module AnalogBridge
   class Response
     attr_reader :response
 

--- a/lib/analogbridge/version.rb
+++ b/lib/analogbridge/version.rb
@@ -1,3 +1,3 @@
-module Analogbridge
-  VERSION = "0.1.0"
+module AnalogBridge
+  VERSION = "0.1.0".freeze
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
-RSpec.describe Analogbridge::Client do
+RSpec.describe AnalogBridge::Client do
   describe ".get_resource" do
     it "loads the resource via :get" do
       stub_get_resource_request("ping")
-      resource = Analogbridge.get_resource("ping")
+      resource = AnalogBridge.get_resource("ping")
 
       expect(resource.data).to eq("Pong!")
     end
@@ -12,7 +12,7 @@ RSpec.describe Analogbridge::Client do
 
   def stub_get_resource_request(end_point)
     stub_request(
-      :get, [Analogbridge.configuration.api_host, end_point].join("/")
+      :get, [AnalogBridge.configuration.api_host, end_point].join("/")
     ).and_return(status: 200, body: JSON.generate(data: "Pong!"))
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 require "analogbridge/configuration"
 
-RSpec.describe Analogbridge::Configuration do
+RSpec.describe AnalogBridge::Configuration do
   describe ".configuration" do
     it "returns the client configuration object" do
       api_host = "https://api.analogbridge.io/v1"
-      configuration = Analogbridge.configuration
+      configuration = AnalogBridge.configuration
 
       expect(configuration.api_host).to eq(api_host)
     end

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
-RSpec.describe Analogbridge::Product do
+RSpec.describe AnalogBridge::Product do
   describe ".all" do
     it "lists all existing product" do
       stub_analogbridge_product_listing
-      products = Analogbridge::Product.all
+      products = AnalogBridge::Product.all
 
       expect(products.count).to eq(2)
       expect(products.first.name).to eq("35mm Slides")

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -17,7 +17,7 @@ module FakeAnalogbridgeApi
   end
 
   def api_end_point(end_point)
-    [Analogbridge.configuration.api_host, end_point].join("/")
+    [AnalogBridge.configuration.api_host, end_point].join("/")
   end
 
   def api_request_headers(data:)


### PR DESCRIPTION
Previously we were using `Analogbridge` as the base namespace for this gem, but our other library are using `AnalogBridge` as their base namespace. So to maintain the consistency, this commit will change it base namespace to `AnalogBridge`.