### PR TITLE
Add `secret_key` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ Or install it yourself as:
 $ gem install analogbridge
 ```
 
+## Configure
+
+Once you have your API Secret keys from Analog Bridge, then you can add an
+initializer to set up your `secret_key` as
+
+```ruby
+AnalogBridge.configure do |config|
+  config.secret_key = "YOUR_SECRET_KEY"
+end
+```
+
+Or
+
+```ruby
+AnalogBridge.configuration.secret_key = "YOUR_SECRET_KEY"
+```
+
 ## Usage
 
 ### Listing Product

--- a/lib/analogbridge/configuration.rb
+++ b/lib/analogbridge/configuration.rb
@@ -1,15 +1,19 @@
 module AnalogBridge
   class Configuration
-    attr_reader :api_base, :api_version
+    attr_accessor :api_base, :api_version, :secret_key
 
     def initialize
-      @api_base = "https://api.analogbridge.io"
-      @api_version = "v1"
+      @api_base ||= "https://api.analogbridge.io"
+      @api_version ||= "v1"
     end
 
     def api_host
       [api_base, api_version].join("/")
     end
+  end
+
+  def self.configure
+    yield configuration
   end
 
   def self.configuration

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -10,4 +10,14 @@ RSpec.describe AnalogBridge::Configuration do
       expect(configuration.api_host).to eq(api_host)
     end
   end
+
+  describe "#secret_key" do
+    it "returns the configured secret key" do
+      AnalogBridge.configure do |config|
+        config.secret_key = "SECURE_SECRET_KEY"
+      end
+
+      expect(AnalogBridge.configuration.secret_key).to eq("SECURE_SECRET_KEY")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,10 @@ RSpec.configure do |config|
   config.before :suite do
     config.include FakeAnalogbridgeApi
   end
+
+  config.before :all do
+    AnalogBridge.configure do |analogbridge_config|
+      analogbridge_config.secret_key = "SECRET_API_KEY"
+    end
+  end
 end


### PR DESCRIPTION
Some of the resource requires a basic authentication, which depends on a `secret_key`, This commit adds a configuration option so user can easily add it through an initializer. Usages

```ruby
AnalogBridge.configure do |config|
  config.secret_key = "YOUR_SECRET_KEY"
end
```