### PR TITLE
Add interface to create customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ AnalogBridge.configuration.secret_key = "YOUR_SECRET_KEY"
 
 ## Usage
 
+### Customer
+
+#### Create Customer
+
+To create a new customer using the API, usage
+
+```ruby
+AnalogBridge::Customer.create(
+  email: "demo@analogbridge.io",
+  shipping: {
+    first_name: "John",
+    last_name: "Smith",
+    address1: "3336 Commercial Ave",
+    city: "Northbrook",
+    state: "IL",
+    zip: "60062",
+    phone: "800-557-3508",
+    email: "demo@analogbridge.io"
+  },
+  metadata: {
+    user_id: "123456",
+  }
+)
+```
+
 ### Listing Product
 
 To retrieve the `products` simply use the following interface

--- a/lib/analogbridge.rb
+++ b/lib/analogbridge.rb
@@ -1,6 +1,8 @@
 require "analogbridge/version"
 require "analogbridge/client"
+require "analogbridge/base"
 require "analogbridge/product"
+require "analogbridge/customer"
 
 module AnalogBridge
 end

--- a/lib/analogbridge/base.rb
+++ b/lib/analogbridge/base.rb
@@ -1,0 +1,11 @@
+module AnalogBridge
+  class Base
+    def self.method_missing(method_name, *arguments, &block)
+      if new.respond_to?(method_name, include_private: false)
+        new.send(method_name, *arguments, &block)
+      else
+        super
+      end
+    end
+  end
+end

--- a/lib/analogbridge/client.rb
+++ b/lib/analogbridge/client.rb
@@ -23,7 +23,7 @@ module AnalogBridge
         method: http_method,
         url: api_end_point,
         payload: attributes,
-        headers: {},
+        user: AnalogBridge.configuration.secret_key,
       )
     end
 
@@ -34,5 +34,9 @@ module AnalogBridge
 
   def self.get_resource(end_point)
     Client.new(:get, end_point).execute
+  end
+
+  def self.post_resource(end_point, attributes)
+    Client.new(:post, end_point, attributes).execute
   end
 end

--- a/lib/analogbridge/customer.rb
+++ b/lib/analogbridge/customer.rb
@@ -1,0 +1,7 @@
+module AnalogBridge
+  class Customer < AnalogBridge::Base
+    def create(attributes = {})
+      AnalogBridge.post_resource("customers", attributes).data
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -10,9 +10,23 @@ RSpec.describe AnalogBridge::Client do
     end
   end
 
+  describe ".post_resource" do
+    it "submit the request via :post" do
+      stub_post_ping_request
+      resource = AnalogBridge.post_resource("ping", {})
+
+      expect(resource.data).to eq("Pong!")
+    end
+  end
+
   def stub_get_resource_request(end_point)
     stub_request(
       :get, [AnalogBridge.configuration.api_host, end_point].join("/")
     ).and_return(status: 200, body: JSON.generate(data: "Pong!"))
+  end
+
+  def stub_post_ping_request
+    stub_request(:post, "https://api.analogbridge.io/v1/ping").
+      to_return(status: 200, body: JSON.generate(data: "Pong!"))
   end
 end

--- a/spec/customer_spec.rb
+++ b/spec/customer_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe AnalogBridge::Customer do
+  describe ".create" do
+    it "creates a new customer" do
+      stub_analogbridge_customer_create(customer_attributes)
+      customer = AnalogBridge::Customer.create(customer_attributes)
+
+      expect(customer.cus_id).not_to be_nil
+      expect(customer.metadata.user_id).to eq(123456)
+      expect(customer.email).to eq("demo@analogbridge.io")
+    end
+  end
+
+  def customer_attributes
+    {
+      email: "demo@analogbridge.io",
+      shipping: {
+        first_name: "John",
+        last_name: "Smith",
+        address1: "3336 Commercial Ave",
+        city: "Northbrook",
+        state: "IL",
+        zip: "60062",
+        phone: "800-557-3508",
+        email: "demo@analogbridge.io",
+      },
+      metadata: {
+        user_id: "123456",
+      },
+    }
+  end
+end

--- a/spec/fixtures/customer_created.json
+++ b/spec/fixtures/customer_created.json
@@ -1,0 +1,26 @@
+{
+  "status": "success",
+  "message": "Customer created successfully",
+  "data": {
+    "cus_id": "cus_28b70539d2b10be293bdeb3c",
+    "auth": "long_auth_token",
+    "expires": 1481310922,
+    "email": "demo@analogbridge.io",
+    "shipping": {
+      "first_name": "John",
+      "last_name": "Smith",
+      "company": null,
+      "address1": "3336 Commercial Ave",
+      "address2": null,
+      "city": "Northbrook",
+      "state": "IL",
+      "zip": "60062",
+      "country": "US",
+      "phone": "800-557-3508",
+      "email": "demo@analogbridge.io"
+    },
+    "metadata": {
+      "user_id": 123456
+    }
+  }
+}

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -1,4 +1,14 @@
 module FakeAnalogbridgeApi
+  def stub_analogbridge_customer_create(attributes)
+    stub_api_response(
+      :post,
+      "customers",
+      data: attributes,
+      filename: "customer_created",
+      status: 200,
+    )
+  end
+
   def stub_analogbridge_product_listing
     stub_api_response(
       :get,
@@ -23,11 +33,12 @@ module FakeAnalogbridgeApi
   def api_request_headers(data:)
     Hash.new.tap do |request_headers|
       request_headers[:body] = data
+      request_headers[:headers] = api_authorization_headers
     end
   end
 
   def api_authorization_headers
-    {}
+    { "Authorization" => "Basic U0VDUkVUX0FQSV9LRVk6" }
   end
 
   def response_with(filename:, status:)


### PR DESCRIPTION
This commit adds the interface to create a new customer, to create a new customer simply use this following interface.

```ruby
AnalogBridge::Customer.create(
  email: "demo@analogbridge.io",
  shipping: {
    first_name: "John",
    last_name: "Smith",
    address1: "3336 Commercial Ave",
    city: "Northbrook",
    state: "IL",
    zip: "60062",
    phone: "800-557-3508",
    email: "demo@analogbridge.io"
  },
  metadata: {
    user_id: "123456"
  }
)
```