### PR TITLE
Add customer retrieval interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ AnalogBridge::Customer.create(
 )
 ```
 
+### Retrieve a Customer
+
+We can easily retrieve a customer details using their `customer_id`, for
+example to find a customer with details with id `cus_12345678`
+
+```ruby
+AnalogBridge::Customer.find("cus_12345678")
+```
+
 ### Listing Product
 
 To retrieve the `products` simply use the following interface

--- a/lib/analogbridge/customer.rb
+++ b/lib/analogbridge/customer.rb
@@ -3,5 +3,11 @@ module AnalogBridge
     def create(attributes = {})
       AnalogBridge.post_resource("customers", attributes).data
     end
+
+    def find(customer_id)
+      AnalogBridge.get_resource(
+        ["customers", customer_id].join("/"),
+      )
+    end
   end
 end

--- a/spec/customer_spec.rb
+++ b/spec/customer_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe AnalogBridge::Customer do
     end
   end
 
+  describe ".find" do
+    it "retrieves the specified customer" do
+      customer_id = "cus_28b70539d2b10be293bdeb3c"
+      stub_analogbridge_customer_find(customer_id)
+      customer = AnalogBridge::Customer.find(customer_id)
+
+      expect(customer.cus_id).to eq(customer_id)
+      expect(customer.metadata.user_id).to eq(123456)
+      expect(customer.email).to eq("demo@analogbridge.io")
+    end
+  end
+
   def customer_attributes
     {
       email: "demo@analogbridge.io",

--- a/spec/fixtures/customer.json
+++ b/spec/fixtures/customer.json
@@ -1,0 +1,22 @@
+{
+  "cus_id": "cus_28b70539d2b10be293bdeb3c",
+  "auth": "long_auth_token",
+  "expires": 1481310922,
+  "email": "demo@analogbridge.io",
+  "shipping": {
+    "first_name": "John",
+    "last_name": "Smith",
+    "company": null,
+    "address1": "3336 Commercial Ave",
+    "address2": null,
+    "city": "Northbrook",
+    "state": "IL",
+    "zip": "60062",
+    "country": "US",
+    "phone": "800-557-3508",
+    "email": "demo@analogbridge.io"
+  },
+  "metadata": {
+    "user_id": 123456
+  }
+}

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -9,6 +9,15 @@ module FakeAnalogbridgeApi
     )
   end
 
+  def stub_analogbridge_customer_find(customer_id)
+    stub_api_response(
+      :get,
+      ["customers", customer_id].join("/"),
+      filename: "customer",
+      status: 200,
+    )
+  end
+
   def stub_analogbridge_product_listing
     stub_api_response(
       :get,


### PR DESCRIPTION
This commit adds the interface to retrieve a specified customer using their customer id, for example: to retrieve a customer with `12345678` `customer_id` use

```ruby
AnalogBridge::Customer.find("12345678")
```