### PR TITLE
Add interface to update a customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,27 @@ AnalogBridge::Customer.create(
 )
 ```
 
-### Retrieve a Customer
+#### Retrieve a Customer
 
 We can easily retrieve a customer details using their `customer_id`, for
 example to find a customer with details with id `cus_12345678`
 
 ```ruby
 AnalogBridge::Customer.find("cus_12345678")
+```
+
+#### Update a customer
+
+Update an existing customer's information by using the `cus_id` from customer
+creation. Any unprovided parameters will have no effect on the customer object.
+The arguments for this call are mainly the same as for the customer creation
+call.
+
+```ruby
+AnalogBridge::Customer.update(
+  "cus_123456789",
+  email: "newemail@analogbridge.io"
+)
 ```
 
 ### Listing Product

--- a/lib/analogbridge/customer.rb
+++ b/lib/analogbridge/customer.rb
@@ -9,5 +9,11 @@ module AnalogBridge
         ["customers", customer_id].join("/"),
       )
     end
+
+    def update(customer_id, attributes = {})
+      AnalogBridge.post_resource(
+        ["customers", customer_id].join("/"), attributes
+      ).data
+    end
   end
 end

--- a/spec/customer_spec.rb
+++ b/spec/customer_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe AnalogBridge::Customer do
     end
   end
 
+  describe ".update" do
+    it "updates an existing customer details" do
+      customer_id = "cus_28b70539d2b10be293bdeb3c"
+      stub_analogbridge_customer_update(customer_id, customer_attributes)
+      customer = AnalogBridge::Customer.update(customer_id, customer_attributes)
+
+      expect(customer.cus_id).to eq(customer_id)
+      expect(customer.metadata.user_id).to eq(123456)
+      expect(customer.email).to eq("demo@analogbridge.io")
+    end
+  end
+
   def customer_attributes
     {
       email: "demo@analogbridge.io",

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -18,6 +18,16 @@ module FakeAnalogbridgeApi
     )
   end
 
+  def stub_analogbridge_customer_update(customer_id, attributes)
+    stub_api_response(
+      :post,
+      ["customers", customer_id].join("/"),
+      data: attributes,
+      filename: "customer_created",
+      status: 200,
+    )
+  end
+
   def stub_analogbridge_product_listing
     stub_api_response(
       :get,


### PR DESCRIPTION
This commit provides an easier way to update an existing customer using their `customer_id`. For example: if we want to add an email to an existing customer with `cus_123456` id then we can use

```ruby
AnalogBridge::Customer.update(
  "cus_123456",
  email: "newemail@example.com"
)
```