### PR TITLE
Add interface to delete customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ AnalogBridge::Customer.update(
 )
 ```
 
+#### Delete a customer
+
+If we need to delete a customer for some reason, then the API got us covered,
+for example if we want to delete a customer with id `cus_123456789` then we can
+use
+
+```ruby
+AnalogBridge::Customer.delete("cus_123456789")
+```
+
 ### Listing Product
 
 To retrieve the `products` simply use the following interface

--- a/lib/analogbridge/client.rb
+++ b/lib/analogbridge/client.rb
@@ -39,4 +39,8 @@ module AnalogBridge
   def self.post_resource(end_point, attributes)
     Client.new(:post, end_point, attributes).execute
   end
+
+  def self.delete_resource(end_point)
+    Client.new(:delete, end_point).execute
+  end
 end

--- a/lib/analogbridge/customer.rb
+++ b/lib/analogbridge/customer.rb
@@ -15,5 +15,11 @@ module AnalogBridge
         ["customers", customer_id].join("/"), attributes
       ).data
     end
+
+    def delete(customer_id)
+      AnalogBridge.delete_resource(
+        ["customers", customer_id].join("/"),
+      ).data
+    end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe AnalogBridge::Client do
     end
   end
 
+  describe ".delete_resource" do
+    it "submits the request via :delete" do
+      stub_delete_ping_request
+      resource = AnalogBridge.delete_resource("ping")
+
+      expect(resource.data).to eq("Pong!")
+    end
+  end
+
   def stub_get_resource_request(end_point)
     stub_request(
       :get, [AnalogBridge.configuration.api_host, end_point].join("/")
@@ -27,6 +36,11 @@ RSpec.describe AnalogBridge::Client do
 
   def stub_post_ping_request
     stub_request(:post, "https://api.analogbridge.io/v1/ping").
+      to_return(status: 200, body: JSON.generate(data: "Pong!"))
+  end
+
+  def stub_delete_ping_request
+    stub_request(:delete, "https://api.analogbridge.io/v1/ping").
       to_return(status: 200, body: JSON.generate(data: "Pong!"))
   end
 end

--- a/spec/customer_spec.rb
+++ b/spec/customer_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe AnalogBridge::Customer do
     end
   end
 
+  describe ".delete" do
+    it "deletes a specified customer" do
+      customer_id = "cus_28b70539d2b10be293bdeb3c"
+      stub_analogbridge_customer_delete(customer_id)
+      customer = AnalogBridge::Customer.delete(customer_id)
+
+      expect(customer.deleted).not_to be_nil
+      expect(customer.cus_id).to eq(customer_id)
+      expect(customer.deleted).not_to be_nil
+    end
+  end
+
   def customer_attributes
     {
       email: "demo@analogbridge.io",

--- a/spec/fixtures/customer_deleted.json
+++ b/spec/fixtures/customer_deleted.json
@@ -1,0 +1,9 @@
+{
+  "success": "success",
+  "message": "Customer deleted successfully",
+  "data" : {
+    "cus_id": "cus_28b70539d2b10be293bdeb3c",
+    "deleted": 1481325743
+  }
+}
+

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -28,6 +28,15 @@ module FakeAnalogbridgeApi
     )
   end
 
+  def stub_analogbridge_customer_delete(customer_id)
+    stub_api_response(
+      :delete,
+      ["customers", customer_id].join("/"),
+      filename: "customer_deleted",
+      status: 200,
+    )
+  end
+
   def stub_analogbridge_product_listing
     stub_api_response(
       :get,


### PR DESCRIPTION
This commit adds the interface to delete a customer specifying by their `customer_id`. For example if we need to delete a customer with a customer id or `cus_123456789` then we can use

```ruby
AnalogBridge::Customer.delete("cus_123456789")
```