### PR TITLE
Add interface to list all customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ example to find a customer with details with id `cus_12345678`
 AnalogBridge::Customer.find("cus_12345678")
 ```
 
+### Retrieve all customers
+
+Analog Bridge provides an interface to retrieve all your customers very easily,
+to retrieve all of your customers, you can use
+
+```ruby
+AnalogBridge::Customer.list(limit: 20, offset: 100)
+```
+
 #### Update a customer
 
 Update an existing customer's information by using the `cus_id` from customer

--- a/lib/analogbridge/customer.rb
+++ b/lib/analogbridge/customer.rb
@@ -1,13 +1,19 @@
 module AnalogBridge
   class Customer < AnalogBridge::Base
-    def create(attributes = {})
-      AnalogBridge.post_resource("customers", attributes).data
-    end
-
     def find(customer_id)
       AnalogBridge.get_resource(
         ["customers", customer_id].join("/"),
       )
+    end
+
+    def all(limit: 20, offset: 0)
+      AnalogBridge.get_resource(
+        "customers?limit=#{limit}&offset=#{offset}",
+      )
+    end
+
+    def create(attributes = {})
+      AnalogBridge.post_resource("customers", attributes).data
     end
 
     def update(customer_id, attributes = {})

--- a/spec/customer_spec.rb
+++ b/spec/customer_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe AnalogBridge::Customer do
     end
   end
 
+  describe ".all" do
+    it "retrieve all the customers" do
+      filters = { limit: "2", offset: "10" }
+      stub_analogbridge_customer_listting(filters)
+      customers = AnalogBridge::Customer.all(filters)
+
+      expect(customers.offset).to eq(10)
+      expect(customers.list.count).to eq(2)
+      expect(customers.total_count).to eq(102)
+      expect(customers.list.last.email).to eq("demo@analogbridge.io")
+    end
+  end
+
   def customer_attributes
     {
       email: "demo@analogbridge.io",

--- a/spec/fixtures/customers.json
+++ b/spec/fixtures/customers.json
@@ -1,0 +1,26 @@
+{
+  "offset": 10,
+  "limit": 20,
+  "total_count": 102,
+  "list": [
+    {
+      "cus_id": "cus_e6bd1537e138d2c3495cdb57",
+      "email": "test@test.com",
+      "metadata": {
+        "user_id": 123456,
+        "custom": {
+          "a": "2",
+          "b": "3"
+        }
+      }
+    },
+    {
+      "cus_id": "cus_d5026c9fee3c48b7d5809682",
+      "email": "demo@analogbridge.io",
+      "metadata": {
+        "user_id": 1234567
+      }
+    }
+  ]
+}
+

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -1,4 +1,13 @@
 module FakeAnalogbridgeApi
+  def stub_analogbridge_customer_listting(limit:, offset:)
+    stub_api_response(
+      :get,
+      "customers?limit=#{limit}&offset=#{offset}",
+      filename: "customers",
+      status: 200,
+    )
+  end
+
   def stub_analogbridge_customer_create(attributes)
     stub_api_response(
       :post,


### PR DESCRIPTION
This commit adds the interface to list all customers, so now the developer can list a specified accounts customer as simple as

```ruby
AnalogBridge::Customer.all(limit: 20)
```