### PR TITLE
Add interface to list all orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ use
 AnalogBridge::Customer.delete("cus_123456789")
 ```
 
+### Order
+
+#### List all orders
+
+The Analog Bridge API allow us to retrieve all orders by specific `customer`.
+For example we want to retrieve all the `order` by a customer id `cus_12345678`
+then we can use
+
+```ruby
+AnalogBridge::Order.where(customer_id: "cus_12345678")
+```
+
 ### Listing Product
 
 To retrieve the `products` simply use the following interface

--- a/lib/analogbridge.rb
+++ b/lib/analogbridge.rb
@@ -1,6 +1,7 @@
 require "analogbridge/version"
 require "analogbridge/client"
 require "analogbridge/base"
+require "analogbridge/order"
 require "analogbridge/product"
 require "analogbridge/customer"
 

--- a/lib/analogbridge/order.rb
+++ b/lib/analogbridge/order.rb
@@ -1,0 +1,9 @@
+module AnalogBridge
+  class Order < AnalogBridge::Base
+    def where(customer_id:)
+      AnalogBridge.get_resource(
+        ["customers", customer_id, "orders"].join("/"),
+      )
+    end
+  end
+end

--- a/spec/fixtures/orders.json
+++ b/spec/fixtures/orders.json
@@ -1,0 +1,39 @@
+[
+  {
+    "ord_id": "ord_fe310b878dc3313c3c2e",
+    "cus_id": "cus_28b70539d2b10be293bdeb3c",
+    "date": "2016-12-08 19:18:30",
+    "total": 89.47,
+    "subtotal": 89.47,
+    "shipping": 0,
+    "order_status": "Order Received from Client",
+    "approval_status": "Approved",
+    "instructions": "Transfer in numbered order",
+    "tracking": null,
+    "items": [
+      {
+        "id": 856962,
+        "date": "1993-09-17 00:00:00",
+        "title": "VHS #1",
+        "is_image": 0,
+        "is_video": 1,
+        "video_hq_url": "https://eterna.gomemorable.com/users/883/883_1000_Eugene-and-Boris-Concert_HQ.mp4",
+        "video_thumb_url": "https://eterna.gomemorable.com/users/883/883_1000_Eugene-and-Boris-Concert_thumb.jpg",
+        "image_hq_url": null,
+        "image_thumb_url": null
+      },
+      {
+        "id": 856963,
+        "date": "1995-09-23 00:00:00",
+        "title": "VHS #2",
+        "is_image": 0,
+        "is_video": 1,
+        "video_hq_url": "https://eterna.gomemorable.com/users/883/883_1000_1995-Jamaica-Cruise-_HQ.mp4",
+        "video_thumb_url": "https://eterna.gomemorable.com/users/883/883_1000_1995-Jamaica-Cruise-_thumb.jpg",
+        "image_hq_url": null,
+        "image_thumb_url": null
+      }
+    ]
+  }
+]
+

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe AnalogBridge::Order do
+  describe ".where" do
+    context "only customer_id provided" do
+      it "retrieves all orders for that customer" do
+        customer_id = "cus_28b70539d2b10be293bdeb3c"
+        stub_analogbridge_order_listing(customer_id: customer_id)
+        orders = AnalogBridge::Order.where(customer_id: customer_id)
+
+        expect(orders.first.items.count).to eq(2)
+        expect(orders.first.cus_id).to eq(customer_id)
+        expect(orders.first.items.first.id).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -46,6 +46,15 @@ module FakeAnalogbridgeApi
     )
   end
 
+  def stub_analogbridge_order_listing(customer_id:)
+    stub_api_response(
+      :get,
+      ["customers", customer_id, "orders"].join("/"),
+      filename: "orders",
+      status: 200,
+    )
+  end
+
   def stub_analogbridge_product_listing
     stub_api_response(
       :get,


### PR DESCRIPTION
This commit adds the interface to retrieve all the orders by a specific customer. For example if we want to retrieve all the orders by a customer id `cus_123456789` then we can use

```ruby
AnalogBridge::Order.where(customer_id: "cus_123456789")
```