### PR TITLE
Add interface to retrieve an order

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ then we can use
 AnalogBridge::Order.where(customer_id: "cus_12345678")
 ```
 
+#### List a order details
+
+If we need to retrieve the details for a specific order then we can use
+
+```ruby
+AnalogBridge::Order.where(
+  order_id: "order_12345678",
+  customer_id: "cus_12345678"
+)
+```
+
 ### Listing Product
 
 To retrieve the `products` simply use the following interface

--- a/lib/analogbridge/order.rb
+++ b/lib/analogbridge/order.rb
@@ -1,8 +1,8 @@
 module AnalogBridge
   class Order < AnalogBridge::Base
-    def where(customer_id:)
+    def where(customer_id:, order_id: nil)
       AnalogBridge.get_resource(
-        ["customers", customer_id, "orders"].join("/"),
+        ["customers", customer_id, "orders", order_id].compact.join("/"),
       )
     end
   end

--- a/spec/fixtures/order.json
+++ b/spec/fixtures/order.json
@@ -1,0 +1,37 @@
+{
+  "ord_id": "ord_fe310b878dc3313c3c2e",
+  "cus_id": "cus_28b70539d2b10be293bdeb3c",
+  "date": "2016-12-08 19:18:30",
+  "total": 89.47,
+  "subtotal": 89.47,
+  "shipping": 0,
+  "order_status": "Order Received from Client",
+  "approval_status": "Approved",
+  "instructions": "Transfer in numbered order",
+  "tracking": null,
+  "items": [
+    {
+      "id": 856962,
+      "date": "1993-09-17 00:00:00",
+      "title": "VHS #1",
+      "is_image": 0,
+      "is_video": 1,
+      "video_hq_url": "https://eterna.gomemorable.com/users/883/883_1000_Eugene-and-Boris-Concert_HQ.mp4",
+      "video_thumb_url": "https://eterna.gomemorable.com/users/883/883_1000_Eugene-and-Boris-Concert_thumb.jpg",
+      "image_hq_url": null,
+      "image_thumb_url": null
+    },
+    {
+      "id": 856963,
+      "date": "1995-09-23 00:00:00",
+      "title": "VHS #2",
+      "is_image": 0,
+      "is_video": 1,
+      "video_hq_url": "https://eterna.gomemorable.com/users/883/883_1000_1995-Jamaica-Cruise-_HQ.mp4",
+      "video_thumb_url": "https://eterna.gomemorable.com/users/883/883_1000_1995-Jamaica-Cruise-_thumb.jpg",
+      "image_hq_url": null,
+      "image_thumb_url": null
+    }
+  ]
+}
+

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -13,5 +13,19 @@ RSpec.describe AnalogBridge::Order do
         expect(orders.first.items.first.id).not_to be_nil
       end
     end
+
+    context "both with customer_id and order_id" do
+      it "retrieve a specific order details" do
+        customer_id = "cus_28b70539d2b10be293bdeb3c"
+        order_id = "ord_fe310b878dc3313c3c2e"
+        stub_analogbridge_order_details(customer_id, order_id)
+        order = AnalogBridge::Order.where(
+          customer_id: customer_id, order_id: order_id,
+        )
+
+        expect(order.cus_id).to eq(customer_id)
+        expect(order.items.first.id).not_to be_nil
+      end
+    end
   end
 end

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -55,6 +55,15 @@ module FakeAnalogbridgeApi
     )
   end
 
+  def stub_analogbridge_order_details(customer_id, order_id)
+    stub_api_response(
+      :get,
+      ["customers", customer_id, "orders", order_id].join("/"),
+      filename: "order",
+      status: 200,
+    )
+  end
+
   def stub_analogbridge_product_listing
     stub_api_response(
       :get,


### PR DESCRIPTION
This commit adds the interface to retrieve a specified order, for example we want to retrieve a specific order for `cus_123456789`, then we can use

```ruby
AnalogBridge::Order.where(
  customer_id: "cus_123456789", order_id: "ord_12345678"
)
```