### PR TITLE
Retrieve import ready orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ AnalogBridge::Order.where(
 )
 ```
 
+#### Retrieve import ready orders
+
+To retrieve the list of of import ready orders, we can use
+
+```ruby
+AnalogBridge::Order.import_ready
+```
+
 ### Listing Product
 
 To retrieve the `products` simply use the following interface

--- a/lib/analogbridge/order.rb
+++ b/lib/analogbridge/order.rb
@@ -1,5 +1,9 @@
 module AnalogBridge
   class Order < AnalogBridge::Base
+    def import_ready
+      AnalogBridge.get_resource("orders/import-ready")
+    end
+
     def where(customer_id:, order_id: nil)
       AnalogBridge.get_resource(
         ["customers", customer_id, "orders", order_id].compact.join("/"),

--- a/spec/fixtures/import_ready_orders.json
+++ b/spec/fixtures/import_ready_orders.json
@@ -1,0 +1,15 @@
+[
+  {
+    "cus_id": "cus_5c5c5254882986ef6745",
+    "orders": [
+      "ord_4f66d77594318f53a4d5",
+      "ord_e6bd1537e138d2c3495c"
+    ]
+  },
+  {
+    "cus_id": "cus_3ab7aa6ec5feda6fe8a3",
+    "orders": [
+      "ord_fe310b878dc3313c3c2e"
+    ]
+  }
+]

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -28,4 +28,14 @@ RSpec.describe AnalogBridge::Order do
       end
     end
   end
+
+  describe ".import_ready" do
+    it "retrieve all the import ready orders" do
+      stub_analogbridge_order_import_ready
+      orders = AnalogBridge::Order.import_ready
+
+      expect(orders.count).to eq(2)
+      expect(orders.first.cus_id).not_to be_nil
+    end
+  end
 end

--- a/spec/support/fake_analogbridge_api.rb
+++ b/spec/support/fake_analogbridge_api.rb
@@ -64,6 +64,15 @@ module FakeAnalogbridgeApi
     )
   end
 
+  def stub_analogbridge_order_import_ready
+    stub_api_response(
+      :get,
+      "orders/import-ready",
+      filename: "import_ready_orders",
+      status: 200,
+    )
+  end
+
   def stub_analogbridge_product_listing
     stub_api_response(
       :get,


### PR DESCRIPTION
This commit adds the interface to retrieve the import ready orders. To retrieve the orders we can simply use

```ruby
AnalogBridge::Order.import_ready
```