### PR TITLE
Rename `.all` interface to `.list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ AnalogBridge::Order.import_ready
 To retrieve the `products` simply use the following interface
 
 ```ruby
-AnalogBridge::Product.all
+AnalogBridge::Product.list
 ```
 
 ## Development

--- a/lib/analogbridge/customer.rb
+++ b/lib/analogbridge/customer.rb
@@ -6,7 +6,7 @@ module AnalogBridge
       )
     end
 
-    def all(limit: 20, offset: 0)
+    def list(limit: 20, offset: 0)
       AnalogBridge.get_resource(
         "customers?limit=#{limit}&offset=#{offset}",
       )

--- a/lib/analogbridge/product.rb
+++ b/lib/analogbridge/product.rb
@@ -1,6 +1,6 @@
 module AnalogBridge
   class Product < AnalogBridge::Base
-    def all
+    def list
       AnalogBridge.get_resource("products")
     end
   end

--- a/spec/customer_spec.rb
+++ b/spec/customer_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe AnalogBridge::Customer do
     end
   end
 
-  describe ".all" do
+  describe ".list" do
     it "retrieve all the customers" do
       filters = { limit: "2", offset: "10" }
       stub_analogbridge_customer_listting(filters)
-      customers = AnalogBridge::Customer.all(filters)
+      customers = AnalogBridge::Customer.list(filters)
 
       expect(customers.offset).to eq(10)
       expect(customers.list.count).to eq(2)

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
 RSpec.describe AnalogBridge::Product do
-  describe ".all" do
+  describe ".list" do
     it "lists all existing product" do
       stub_analogbridge_product_listing
-      products = AnalogBridge::Product.all
+      products = AnalogBridge::Product.list
 
       expect(products.count).to eq(2)
       expect(products.first.name).to eq("35mm Slides")


### PR DESCRIPTION
For the `product` and `customer`, we had two interfaces, which is basically retrieving the lists of customers or products, it does not feel right, so let's rename that interface to call `.list`.