### PR TITLE
Add support for major releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
+  - 2.2.0
+  - 2.1.9
 before_install: gem install bundler -v 1.13.6


### PR DESCRIPTION
Currently, Travis CI is only running the test suite for ruby version `2.3.1`, but we want need some backward compatibility, so this commit adds some other major versions (2.2.0, 2.1.9), so now whenever there is a new PR then it will make sure our test suite passes on the all of the major versions.